### PR TITLE
Set relative path instead of absolute for files

### DIFF
--- a/discover_jenkins/tasks/run_pep8.py
+++ b/discover_jenkins/tasks/run_pep8.py
@@ -79,7 +79,7 @@ class Pep8Task(object):
         )
 
         for location in locations:
-            pep8style.input_dir(location)
+            pep8style.input_dir(os.path.relpath(location))
 
         self.output.close()
 


### PR DESCRIPTION
Jenkins violations plugin requires the relative path in order to properly link the file when looking at violations report
