### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ django-discover-jenkins
   
 A streamlined fork of django-jenkins designed to work with the default test command and the discover runner.
 
-[Read the Docs](https://django-discover-jenkins.readthedocs.org/)
+[Read the Docs](https://django-discover-jenkins.readthedocs.io/)
 
 Why?
 ----


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.